### PR TITLE
Support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/harmonic/inertiatable",
     "keywords": ["Laravel", "inertiajs", "inertia", "InertiaTable"],
     "require": {
-        "illuminate/support": "~5",
+        "illuminate/support": "~5||~6",
         "inertiajs/inertia-laravel": "^0.1.0",
         "symfony/process": "^4.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,14 @@
     "homepage": "https://github.com/harmonic/inertiatable",
     "keywords": ["Laravel", "inertiajs", "inertia", "InertiaTable"],
     "require": {
-        "illuminate/support": "~5||~6",
+        "illuminate/support": "~5 || ~6",
         "inertiajs/inertia-laravel": "^0.1.0",
         "symfony/process": "^4.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0",
         "mockery/mockery": "^1.1",
-        "orchestra/testbench": "~3.0",
+        "orchestra/testbench": "~3.0 || ~4.0",
         "sempro/phpunit-pretty-print": "^1.0"
     },
     "autoload": {

--- a/src/InertiaTable.php
+++ b/src/InertiaTable.php
@@ -2,6 +2,7 @@
 
 namespace harmonic\InertiaTable;
 
+use Illuminate\Database\Eloquent\Model;
 use Inertia\Inertia;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Schema;
@@ -12,12 +13,12 @@ class InertiaTable
     /**
      * Generates inertia view data for model.
      *
-     * @param InertiaModel $model The model to use to retrieve data
+     * @param Model $model The model to use to retrieve data
      * @param array $columns An array of column names to send to front end (null for all columns)'
      * @param array $filterable A subset of the $columns array containing names of columsn that can be filtered
      * @return void
      */
-    public function index(InertiaModel $model, array $columns = null, array $filterable = null)
+    public function index(Model $model, array $columns = null, array $filterable = null)
     {
         $modelName = class_basename($model);
 

--- a/src/InertiaTable.php
+++ b/src/InertiaTable.php
@@ -36,7 +36,7 @@ class InertiaTable
             'filters' => Request::all('search', 'trashed'),
             'order' => Request::all('orderColumn', 'orderDirection'),
             strtolower($modelPlural) => $model
-                ->order(Request::input('orderColumn') ?? 'name', Request::input('orderDirection'))
+                ->order(Request::input('orderColumn') ?? $model->getKeyName(), Request::input('orderDirection'))
                 ->filter(Request::only('search', 'trashed'), $filterable)
                 ->get()
                 ->transform(function ($item) use ($columns) {

--- a/src/InertiaTableServiceProvider.php
+++ b/src/InertiaTableServiceProvider.php
@@ -4,6 +4,7 @@ namespace harmonic\InertiaTable;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class InertiaTableServiceProvider extends ServiceProvider
 {
@@ -18,26 +19,24 @@ class InertiaTableServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        // $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'harmonic');
-        // $this->loadViewsFrom(__DIR__.'/../resources/views', 'harmonic');
-        // $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        // $this->loadRoutesFrom(__DIR__.'/routes.php');
-
         // Easily create all the inertia routes
-        Route::macro('inertiaTable', function ($routeName) {
+        Route::macro('inertiaTable', function ($routeName, $routeKey = null) {
             $routeName = strtolower($routeName);
+            $routeKey = $routeKey ? $routeKey : Str::singular($routeName);
+            $routePlaceholder = sprintf('{%s}', $routeKey);
             $controller = ucfirst($routeName).'Controller';
+
 
             Route::group([
                 'prefix' => '/'.$routeName,
-            ], function () use ($controller, $routeName) {
+            ], function () use ($controller, $routeName, $routePlaceholder) {
                 Route::get('/')->name($routeName)->uses($controller.'@index')->middleware('remember');
                 Route::get('/create')->name($routeName.'.create')->uses($controller.'@create');
                 Route::post('/')->name($routeName.'.store')->uses($controller.'@store');
-                Route::get('/{'.$routeName.'}/edit')->name($routeName.'.edit')->uses($controller.'@edit');
-                Route::put('/{'.$routeName.'}')->name($routeName.'.update')->uses($controller.'@update');
-                Route::delete('/{'.$routeName.'}')->name($routeName.'.destroy')->uses($controller.'@destroy');
-                Route::put('/{'.$routeName.'}/restore')->name($routeName.'.restore')->uses($controller.'@restore');
+                Route::get(sprintf('/%s/edit', $routePlaceholder))->name($routeName.'.edit')->uses($controller.'@edit');
+                Route::put(sprintf('/%s', $routePlaceholder))->name($routeName.'.update')->uses($controller.'@update');
+                Route::delete(sprintf('/%s', $routePlaceholder))->name($routeName.'.destroy')->uses($controller.'@destroy');
+                Route::put(sprintf('/%s/restore', $routePlaceholder))->name($routeName.'.restore')->uses($controller.'@restore');
             });
         });
 
@@ -85,23 +84,5 @@ class InertiaTableServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/inertiatable.php' => config_path('inertiatable.php'),
         ], 'inertiatable.config');
-
-        // Publishing the views.
-        /*$this->publishes([
-            __DIR__.'/../resources/views' => base_path('resources/views/vendor/harmonic'),
-        ], 'inertiatable.views');*/
-
-        // Publishing assets.
-        /*$this->publishes([
-            __DIR__.'/../resources/assets' => public_path('vendor/harmonic'),
-        ], 'inertiatable.views');*/
-
-        // Publishing the translation files.
-        /*$this->publishes([
-            __DIR__.'/../resources/lang' => resource_path('lang/vendor/harmonic'),
-        ], 'inertiatable.views');*/
-
-        // Registering package commands.
-        // $this->commands([]);
     }
 }

--- a/src/InertiaTableServiceProvider.php
+++ b/src/InertiaTableServiceProvider.php
@@ -20,11 +20,11 @@ class InertiaTableServiceProvider extends ServiceProvider
     public function boot()
     {
         // Easily create all the inertia routes
-        Route::macro('inertiaTable', function ($routeName, $routeKey = null) {
+        Route::macro('inertiaTable', function ($routeName, $controller = null, $routeKey = null) {
             $routeName = strtolower($routeName);
             $routeKey = $routeKey ? $routeKey : Str::singular($routeName);
             $routePlaceholder = sprintf('{%s}', $routeKey);
-            $controller = ucfirst($routeName).'Controller';
+            $controller = $controller ? $controller : ucfirst($routeName).'Controller';
 
 
             Route::group([


### PR DESCRIPTION
This PR updates the library to support laravel 6. 
I may have missed some things, but i'm testing as I go so I should find any bugs :)

The main breaking change is that the route placeholder must be exactly the lowercase version of the model name.

I've updated the service provider to generate routes that will match correctly by using the singular version of the name. If they are not using plural versions, I added a second optional param to pass it in.