### PR TITLE
fix: bump inertia versions + fix remember middleware bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to `InertiaTable` will be documented in this file.
 
+## Version 1.0.7
+
+### Added
+- Support inertia 0.2.x
+- Add missing `remember` middleware package + install docs
+
 ## Version 1.0.6
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "keywords": ["Laravel", "inertiajs", "inertia", "InertiaTable"],
     "require": {
         "illuminate/support": "~5 || ~6",
-        "inertiajs/inertia-laravel": "^0.1.0",
+        "inertiajs/inertia-laravel": "^0.2.0",
+        "reinink/remember-query-strings": "^0.1.0",
         "symfony/process": "^4.3"
     },
     "require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,15 @@ Via Composer
 $ composer require harmonic/inertia-table
 ```
 
+Register the `remember` route middleware in your `App\HttpKernel` class:
+
+```php
+protected $routeMiddleware = [
+    // ..
+    'remember' => \Reinink\RememberQueryStrings::class,
+];
+```
+
 ## Usage
 
 ### Via CLI


### PR DESCRIPTION
This bumps interia to the latest (no breaking changes) + fixes #16 by adding the package & install instructions. This this is because it's installed/setup in the preset usually, but is missing from default laravel.